### PR TITLE
app: overhaul table UI with strategy dock, outcomes table, and realis…

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,22 +1,9 @@
+import GameTable from './components/GameTable.jsx'
+import StrategyDock from './components/StrategyDock.jsx'
 import { useState } from 'react'
 
 export default function App() {
-  const [result, setResult] = useState(null)
-  const [loading, setLoading] = useState(false)
-
-  async function pingApi() {
-    setLoading(true)
-    try {
-      const res = await fetch('/api/hello')
-      const json = await res.json()
-      setResult(json)
-    } catch (e) {
-      setResult({ ok: false, error: 'fetch_failed' })
-    } finally {
-      setLoading(false)
-    }
-  }
-
+  const [strategyInfo, setStrategyInfo] = useState(null)
   return (
     <div style={{
       minHeight: '100vh',
@@ -27,34 +14,44 @@ export default function App() {
       color: '#fff',
       fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif'
     }}>
-      <main style={{ textAlign: 'center', padding: 24 }}>
-        <h1 style={{ margin: '0 0 8px' }}>Test Branch Web App</h1>
-        <p style={{ opacity: 0.9, marginBottom: 16 }}>Minimal page to verify deploy + API</p>
+      {/* Logo top-left */}
+      <a href='/' aria-label='Caseeno Home' style={{
+        position: 'fixed', top: 12, left: 12, display: 'inline-flex', alignItems: 'center', gap: 8,
+        color: 'inherit', textDecoration: 'none', zIndex: 50
+      }}>
+        <img src='/icons/logo.svg' alt='' width='28' height='28' style={{ filter: 'drop-shadow(0 1px 0 rgba(0,0,0,0.4))' }} />
+        <strong style={{ letterSpacing: 0.3 }}>Caseeno</strong>
+      </a>
+      <main style={{ textAlign: 'center', padding: 24, width: 'min(1040px, 100%)' }}>
+        <h1 style={{ margin: '0 0 8px' }}>Caseeno Blackjack</h1>
+        <p style={{ opacity: 0.9, marginBottom: 16 }}>Phase 0 foundation: UI shell + game core</p>
 
-        <button onClick={pingApi} disabled={loading} style={{
-          padding: '10px 16px',
-          borderRadius: 8,
-          background: '#5bc0be',
-          color: '#0b132b',
-          fontWeight: 600,
-          border: 0,
-          cursor: 'pointer'
+        <div className='table-felt' style={{
+          position: 'relative',
+          margin: '0 auto',
+          width: 'min(980px, 95vw)',
+          height: '70vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 24,
+          borderRadius: 9999,
+          background: 'radial-gradient(120% 120% at 50% 10%, #2a9d8f 0%, #1b5e54 60%, #0f3b35 100%)',
+          boxShadow: '0 40px 80px rgba(0,0,0,0.45), inset 0 2px 8px rgba(255,255,255,0.08)',
+          border: '2px solid rgba(0,0,0,0.3)'
         }}>
-          {loading ? 'Pinging…' : 'Ping /api/hello'}
-        </button>
-
-        <pre style={{
-          marginTop: 16,
-          textAlign: 'left',
-          background: 'rgba(255,255,255,0.08)',
-          border: '1px solid rgba(255,255,255,0.12)',
-          borderRadius: 12,
-          padding: 16,
-          whiteSpace: 'pre-wrap'
-        }}>
-{JSON.stringify(result, null, 2)}
-        </pre>
+          {/* Seats */}
+          <div className='seats' aria-hidden='true'>
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className={`seat seat-${i+1}`} />
+            ))}
+          </div>
+          <section style={{ width: 'min(900px, 100%)', height: '100%' }}>
+            <GameTable onStrategyContext={setStrategyInfo} />
+          </section>
+        </div>
       </main>
+      <StrategyDock context={strategyInfo} />
     </div>
   )
 }

--- a/app/src/components/GameTable.jsx
+++ b/app/src/components/GameTable.jsx
@@ -1,0 +1,368 @@
+import { useMemo, useState } from 'react'
+import { startRound, playerHit, playerStand } from '../game/engine.js'
+import { handValue } from '../game/hand.js'
+import { formatCard } from '../game/deck.js'
+import { basicStrategy, formatSuggestion } from '../game/strategy.js'
+import StrategyHelp from './StrategyHelp.jsx'
+import { useEffect } from 'react'
+
+function Card({ c, hidden = false, delayMs = 0 }) {
+  const isRed = c?.suit === '♥' || c?.suit === '♦'
+  const rank = c?.rank
+  const suit = c?.suit
+  if (hidden) {
+    return (
+      <div
+        className='card card-back'
+        style={{
+          width: 88,
+          height: 120,
+          borderRadius: 10,
+          animation: 'fadeUp 320ms ease-out both',
+          animationDelay: `${delayMs}ms`
+        }}
+        title='Hidden'
+      />
+    )
+  }
+  return (
+    <div
+      className={`card playing-card ${isRed ? 'red' : 'black'}`}
+      style={{
+        width: 88,
+        height: 120,
+        borderRadius: 10,
+        animation: 'fadeUp 320ms ease-out both',
+        animationDelay: `${delayMs}ms`
+      }}
+      title={`${rank}${suit}`}
+    >
+      <div className='corner top-left'>
+        <div className='rank'>{rank}</div>
+        <div className='suit'>{suit}</div>
+      </div>
+      <div className='corner bottom-right'>
+        <div className='rank'>{rank}</div>
+        <div className='suit'>{suit}</div>
+      </div>
+      {isFace(rank) ? (
+        <>
+          <div className='watermark'>{suit}</div>
+          <div className='face-art'>{rank}</div>
+        </>
+      ) : rank === 'A' ? (
+        <div className='pip ace'>{suit}</div>
+      ) : (
+        <div className='pips'>
+          {getPipCoords(rank).map(([x, y], i) => (
+            <div key={i} className='pip' style={{ left: `${x}%`, top: `${y}%` }}>{suit}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function isFace(r) { return r === 'J' || r === 'Q' || r === 'K' }
+
+function getPipCoords(rank) {
+  const center = [50, 50]
+  const top = 25, upper = 35, middle = 50, lower = 65, bottom = 75
+  const left = 30, right = 70, centerX = 50
+  switch (rank) {
+    case '2': return [[centerX, top], [centerX, bottom]]
+    case '3': return [[centerX, top], center, [centerX, bottom]]
+    case '4': return [[left, top], [right, top], [left, bottom], [right, bottom]]
+    case '5': return [[left, top], [right, top], center, [left, bottom], [right, bottom]]
+    case '6': return [[left, top], [right, top], [left, middle], [right, middle], [left, bottom], [right, bottom]]
+    case '7': return [[left, top], [right, top], [left, middle], [right, middle], [left, bottom], [right, bottom], [centerX, upper]]
+    case '8': return [[left, top], [right, top], [left, middle], [right, middle], [left, bottom], [right, bottom], [centerX, upper], [centerX, lower]]
+    case '9': return [[left, top], [right, top], [left, middle], [right, middle], [left, bottom], [right, bottom], [centerX, upper], [centerX, middle], [centerX, lower]]
+    case '10': return [[left, top], [centerX, top], [right, top], [left, middle], [right, middle], [left, bottom], [centerX, bottom], [right, bottom], [centerX, upper], [centerX, lower]]
+    default: return []
+  }
+}
+
+export default function GameTable({ onStrategyContext }) {
+  const rng = useMemo(() => undefined, [])
+  const [state, setState] = useState(null)
+  const [showHelp, setShowHelp] = useState(false)
+  const [history, setHistory] = useState([])
+
+  const phase = state?.phase ?? 'idle'
+  const player = state?.player ?? []
+  const dealer = state?.dealer ?? []
+
+  function onStart() {
+    const s = startRound(rng)
+    setState(s)
+    if (s.phase === 'ended' && s.outcome) {
+      recordOutcome(s.outcome)
+    }
+  }
+  function onHit() {
+    setState(s => {
+      const next = { ...playerHit({ ...s, player: [...s.player], dealer: [...s.dealer], deck: [...s.deck] }) }
+      if (next.phase === 'ended' && next.outcome) {
+        recordOutcome(next.outcome)
+      }
+      return next
+    })
+  }
+  function onStand() {
+    setState(s => {
+      const next = { ...playerStand({ ...s, player: [...s.player], dealer: [...s.dealer], deck: [...s.deck] }) }
+      if (next.phase === 'ended' && next.outcome) {
+        recordOutcome(next.outcome)
+      }
+      return next
+    })
+  }
+  function onReset() {
+    setState(null)
+  }
+
+  function recordOutcome(code) {
+    const entry = { code, label: outcomeLabel(code), type: outcomeType(code) }
+    setHistory(h => [entry, ...h].slice(0, 10))
+  }
+
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === '?') setShowHelp(true)
+      if (e.key === '/') {
+        // Some keyboards require Shift+/ for '?'; support '/' as well
+        setShowHelp(true)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  const dealerFaceDown = phase === 'player'
+  const dealerShown = dealerFaceDown && dealer.length > 0 ? [dealer[0], null] : dealer
+  const dealerUp = dealer.length > 0 ? dealer[0] : null
+
+  const status = (() => {
+    if (phase === 'idle') return 'Click Deal to begin'
+    if (phase === 'player') return 'Your turn: Hit or Stand'
+    if (phase === 'dealer') return 'Dealer playing…'
+    if (phase === 'ended') return outcomeLabel(state?.outcome)
+    return ''
+  })()
+
+  const suggestion = phase === 'player' && player.length > 0 && dealerUp
+    ? basicStrategy(player, dealerUp)
+    : null
+  const suggestedAction = suggestion?.primary === 'double' ? (suggestion?.fallback || 'hit') : suggestion?.primary
+
+  // Provide lightweight context to StrategyDock for highlighting
+  useEffect(() => {
+    if (!onStrategyContext) return
+    if (phase !== 'player' || player.length === 0 || !dealerUp) {
+      onStrategyContext(null)
+      return
+    }
+    const info = computeHandInfo(player)
+    const up = upRankValue(dealerUp)
+    onStrategyContext({
+      total: info.total,
+      soft: info.soft,
+      up,
+      suggestion: suggestion?.primary || null,
+      fallback: suggestion?.fallback || null
+    })
+  }, [phase, player, dealerUp, suggestion, onStrategyContext])
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      {/* Dealer row at top */}
+      <div style={{ position: 'absolute', top: 20, left: '50%', transform: 'translateX(-50%)', textAlign: 'center' }}>
+        <div style={{ opacity: 0.9, marginBottom: 8 }}>Dealer {dealer.length ? `(${dealerFaceDown ? '?' : handValue(dealer)})` : ''}</div>
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+          {dealerShown.map((c, i) => <Card key={i} c={c} hidden={c == null} delayMs={i * 90} />)}
+        </div>
+      </div>
+
+      {/* Player row at bottom */}
+      <div style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', textAlign: 'center' }}>
+        <div style={{ opacity: 0.9, marginBottom: 8 }}>Player {player.length ? `(${handValue(player)})` : ''}</div>
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+          {player.map((c, i) => <Card key={i} c={c} delayMs={i * 90 + 120} />)}
+        </div>
+      </div>
+
+      {/* Center controls and status */}
+      <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', textAlign: 'center' }}>
+        <div style={{ opacity: 0.9, marginBottom: 10 }}>{status}</div>
+        {/* strategy hint line removed per request */}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'center', alignItems: 'center' }}>
+          {phase === 'idle' && (
+            <Btn onClick={onStart}>Deal</Btn>
+          )}
+          {phase === 'player' && (
+            <>
+              <Btn onClick={onHit} variant='hit' highlight={suggestedAction === 'hit'}>Hit</Btn>
+              <Btn onClick={onStand} variant='stand' highlight={suggestedAction === 'stand'}>Stand</Btn>
+            </>
+          )}
+          {phase === 'ended' && (
+            <>
+              <Btn onClick={onStart}>Deal Again</Btn>
+              <Btn variant='ghost' onClick={onReset}>Reset</Btn>
+            </>
+          )}
+        </div>
+        <div style={{ marginTop: 8, fontSize: 12, opacity: 0.7 }}>Press ? for strategy help</div>
+      </div>
+
+      <StrategyHelp open={showHelp} onClose={() => setShowHelp(false)} />
+
+      {/* Outcomes panel (top-right) */}
+      <div className='panel panel--outcomes' style={{
+        position: 'fixed', top: 12, right: 12, zIndex: 40,
+        background: 'rgba(15,26,58,0.9)', color: '#fff', borderRadius: 10,
+        border: '1px solid rgba(255,255,255,0.15)', padding: 12,
+        minWidth: 260, backdropFilter: 'blur(4px)'
+      }}>
+        <div style={{ fontWeight: 700, marginBottom: 8 }}>Last 10 Outcomes</div>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+          <thead>
+            <tr style={{ opacity: 0.8 }}>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>#</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Outcome</th>
+              <th style={{ textAlign: 'center', paddingBottom: 6 }}>Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.map((h, i) => (
+              <tr key={i} style={{ animation: 'fadeUp 180ms ease-out both', animationDelay: `${i * 30}ms` }}>
+                <td style={{ padding: '4px 0', opacity: 0.8 }}>{i + 1}</td>
+                <td style={{ padding: '4px 0' }}>{h.label}</td>
+                <td style={{ padding: '4px 0', textAlign: 'center' }}>
+                  <span className={`chip chip--${outcomeVariant(h.code)}`}>{h.type}</span>
+                </td>
+              </tr>
+            ))}
+            {history.length === 0 && (
+              <tr>
+                <td colSpan='3' style={{ padding: '6px 0', opacity: 0.8 }}>No outcomes yet</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function Row({ title, children }) {
+  return (
+    <div>
+      <div style={{ opacity: 0.9, marginBottom: 10, fontSize: 14 }}>{title}</div>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', justifyContent: 'center', minHeight: 130 }}>{children}</div>
+    </div>
+  )
+}
+
+function Btn({ onClick, children, variant, highlight }) {
+  let styles
+  if (variant === 'ghost') {
+    styles = {
+      background: 'transparent', color: '#e0fbfc', border: '1px solid rgba(255,255,255,0.35)'
+    }
+  } else if (variant === 'hit') {
+    styles = { background: '#2ecc71', color: '#0b132b', border: 0 }
+  } else if (variant === 'stand') {
+    styles = { background: '#f1c40f', color: '#0b132b', border: 0 }
+  } else {
+    styles = { background: '#5bc0be', color: '#0b132b', border: 0 }
+  }
+  if (highlight) {
+    styles = {
+      ...styles,
+      boxShadow: '0 0 0 3px rgba(255,255,255,0.15), 0 10px 24px rgba(0,0,0,0.35)',
+      transform: 'translateY(-1px)'
+    }
+  }
+  return (
+    <button className='btn' onClick={onClick} style={{
+      padding: '14px 22px',
+      borderRadius: 12,
+      fontWeight: 700,
+      fontSize: 16,
+      cursor: 'pointer',
+      transition: 'transform 120ms ease, box-shadow 200ms ease, background 200ms ease, color 200ms ease',
+      willChange: 'transform',
+      ...styles
+    }}>
+      {children}
+    </button>
+  )
+}
+
+function outcomeLabel(code) {
+  switch (code) {
+    case 'player_blackjack': return 'Blackjack! You win'
+    case 'dealer_blackjack': return 'Dealer Blackjack — you lose'
+    case 'player_bust': return 'Bust — you lose'
+    case 'dealer_bust': return 'Dealer busts — you win'
+    case 'player_win': return 'You win'
+    case 'dealer_win': return 'Dealer wins'
+    case 'push': return 'Push'
+    default: return ''
+  }
+}
+
+function outcomeVariant(code) {
+  switch (code) {
+    case 'player_blackjack':
+      return 'bj'
+    case 'dealer_bust':
+    case 'player_win':
+      return 'win'
+    case 'dealer_blackjack':
+    case 'player_bust':
+    case 'dealer_win':
+      return 'lose'
+    case 'push':
+    default:
+      return 'push'
+  }
+}
+
+function outcomeType(code) {
+  switch (code) {
+    case 'player_blackjack':
+    case 'dealer_bust':
+    case 'player_win':
+      return 'Win'
+    case 'dealer_blackjack':
+    case 'player_bust':
+    case 'dealer_win':
+      return 'Lose'
+    case 'push':
+    default:
+      return 'Push'
+  }
+}
+
+function computeHandInfo(cards) {
+  let total = 0
+  let aces = 0
+  for (const c of cards) {
+    if (c.rank === 'A') { aces += 1; total += 11 }
+    else if (['K', 'Q', 'J'].includes(c.rank)) total += 10
+    else total += Number(c.rank)
+  }
+  let softAces = aces
+  while (total > 21 && softAces > 0) { total -= 10; softAces -= 1 }
+  return { total, soft: softAces > 0 }
+}
+
+function upRankValue(up) {
+  if (!up) return 0
+  if (up.rank === 'A') return 11
+  if (['K', 'Q', 'J'].includes(up.rank)) return 10
+  return Number(up.rank)
+}

--- a/app/src/components/StrategyDock.jsx
+++ b/app/src/components/StrategyDock.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+
+export default function StrategyDock({ context }) {
+  const [open, setOpen] = useState(false)
+
+  if (!open) {
+    return (
+      <button
+        className='dock dock--closed'
+        onClick={() => setOpen(true)}
+        style={{
+          position: 'fixed', bottom: 12, right: 12, zIndex: 60,
+          background: 'rgba(15,26,58,0.95)', color: '#e0fbfc',
+          border: '1px solid rgba(255,255,255,0.2)', borderRadius: 9999,
+          padding: '10px 14px', cursor: 'pointer',
+          boxShadow: '0 8px 20px rgba(0,0,0,0.35)'
+        }}
+        aria-label='Open strategy'
+      >
+        Strategy ▴
+      </button>
+    )
+  }
+
+  // Data-driven rules for highlighting
+  const hardRules = [
+    { key: 'h17p', label: '17+', match: t => t >= 17, action: 'stand', vs: 'Any' },
+    { key: 'h16', label: '16', match: t => t === 16, action: 'stand', vs: '2–6', else: 'hit' },
+    { key: 'h15', label: '15', match: t => t === 15, action: 'stand', vs: '2–6', else: 'hit' },
+    { key: 'h13_14', label: '13–14', match: t => t >= 13 && t <= 14, action: 'stand', vs: '2–6', else: 'hit' },
+    { key: 'h12', label: '12', match: t => t === 12, action: 'stand', vs: '4–6', else: 'hit' },
+    { key: 'h11', label: '11', match: t => t === 11, action: 'double', vs: '2–10', else: 'hit' },
+    { key: 'h10', label: '10', match: t => t === 10, action: 'double', vs: '2–9', else: 'hit' },
+    { key: 'h9', label: '9', match: t => t === 9, action: 'double', vs: '3–6', else: 'hit' },
+    { key: 'h8m', label: '8 or less', match: t => t <= 8, action: 'hit', vs: 'Any' }
+  ]
+  const softRules = [
+    { key: 's19p', label: 'A,8+ (19–21)', match: t => t >= 19, action: 'stand', vs: 'Any' },
+    { key: 's18', label: 'A,7 (18)', match: t => t === 18, action: 'double', vs: '3–6', else: 'stand', elseNote: 'vs 2/7/8 Stand; else Hit' },
+    { key: 's17', label: 'A,6 (17)', match: t => t === 17, action: 'double', vs: '3–6', else: 'hit' },
+    { key: 's15_16', label: 'A,4–A,5 (15–16)', match: t => t >= 15 && t <= 16, action: 'double', vs: '4–6', else: 'hit' },
+    { key: 's13_14', label: 'A,2–A,3 (13–14)', match: t => t >= 13 && t <= 14, action: 'double', vs: '5–6', else: 'hit' }
+  ]
+
+  function upInRange(range, up) {
+    if (range === 'Any') return true
+    // ranges like '2–6', '3–6', '4–6', '2–10', '5–6'
+    const [a, b] = range.split('–').map(x => (x === 'A' ? 11 : Number(x)))
+    return up >= a && up <= b
+  }
+
+  function isHighlighted(rule) {
+    if (!context) return false
+    const t = context.total
+    const up = context.up
+    const inRange = upInRange(rule.vs, up)
+    const matchesTotal = rule.match(t)
+    const suggested = context.suggestion
+    const fallback = context.fallback
+    if (!(matchesTotal && inRange)) return false
+    // highlight if primary or fallback matches suggested/fallback
+    return suggested === rule.action || (!!rule.else && (suggested === rule.else || fallback === rule.else))
+  }
+
+  return (
+    <div
+      className='dock dock--open'
+      style={{
+        position: 'fixed', bottom: 12, right: 12, zIndex: 60,
+        width: 'min(380px, 92vw)', maxHeight: '70vh', overflow: 'auto',
+        background: 'rgba(15,26,58,0.97)', color: '#fff', borderRadius: 12,
+        border: '1px solid rgba(255,255,255,0.25)',
+        boxShadow: '0 16px 28px rgba(0,0,0,0.45)', animation: 'pop 200ms ease-out both'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 12px', borderBottom: '1px solid rgba(255,255,255,0.15)' }}>
+        <strong>Strategy</strong>
+        <button onClick={() => setOpen(false)} className='btn' style={{
+          background: 'transparent', color: '#e0fbfc', border: '1px solid rgba(255,255,255,0.3)',
+          padding: '6px 10px', borderRadius: 8, cursor: 'pointer'
+        }}>Close</button>
+      </div>
+      <div style={{ padding: 12 }}>
+        <Legend />
+        <Section title='Hard Totals'>
+          {hardRules.map(r => (
+            <RuleRow key={r.key} rule={r} highlight={context && !context.soft && isHighlighted(r)} />
+          ))}
+        </Section>
+
+        <Section title='Soft Totals (A=11)'>
+          {softRules.map(r => (
+            <RuleRow key={r.key} rule={r} highlight={context && context.soft && isHighlighted(r)} />
+          ))}
+        </Section>
+      </div>
+    </div>
+  )
+}
+
+function Legend() {
+  return (
+    <div style={{ display: 'flex', gap: 8, marginBottom: 8, fontSize: 12, alignItems: 'center' }}>
+      <span className='tag act-stand'>Stand</span>
+      <span className='tag act-hit'>Hit</span>
+      <span className='tag act-double'>Double</span>
+      <span style={{ opacity: 0.75 }}>| If Double unavailable, fallback indicated in notes.</span>
+    </div>
+  )
+}
+
+function Section({ title, children }) {
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
+      <div style={{ display: 'grid', gap: 6 }}>{children}</div>
+    </div>
+  )
+}
+
+function RuleRow({ rule, highlight }) {
+  return (
+    <div className={highlight ? 'row row--current' : 'row'} style={{
+      display: 'grid', gridTemplateColumns: '140px 80px 1fr', gap: 8, alignItems: 'center',
+      background: highlight ? 'rgba(159,255,199,0.12)' : 'rgba(255,255,255,0.05)',
+      border: `1px solid ${highlight ? 'rgba(159,255,199,0.55)' : 'rgba(255,255,255,0.12)'}`,
+      borderRadius: 8, padding: '6px 8px'
+    }}>
+      <div style={{ opacity: 0.95 }}>{rule.label}</div>
+      <div style={{ textAlign: 'center' }}>{rule.vs}</div>
+      <div>
+        <span className={`tag act-${rule.action}`}>{cap(rule.action)}</span>
+        {rule.else && (
+          <>
+            <span style={{ margin: '0 4px', opacity: 0.8 }}>else</span>
+            <span className={`tag act-${rule.else}`}>{cap(rule.else)}</span>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function cap(s) { return s[0].toUpperCase() + s.slice(1) }

--- a/app/src/components/StrategyHelp.jsx
+++ b/app/src/components/StrategyHelp.jsx
@@ -1,0 +1,89 @@
+import { useEffect } from 'react'
+
+export default function StrategyHelp({ open, onClose }) {
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'Escape') onClose?.()
+    }
+    if (open) window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className='overlay' style={{
+      position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50,
+      animation: 'fadeIn 200ms ease-out both'
+    }} onClick={onClose}>
+      <div className='dialog' role='dialog' aria-modal='true' onClick={(e) => e.stopPropagation()} style={{
+        width: 'min(820px, 95vw)', maxHeight: '85vh', overflow: 'auto',
+        background: '#0f1a3a', color: '#fff', borderRadius: 12,
+        border: '1px solid rgba(255,255,255,0.2)', boxShadow: '0 10px 30px rgba(0,0,0,0.5)',
+        animation: 'pop 220ms cubic-bezier(.2,.8,.2,1) both'
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderBottom: '1px solid rgba(255,255,255,0.15)' }}>
+          <strong>Basic Strategy — S17, no splits/surrender</strong>
+          <button onClick={onClose} aria-label='Close' style={{
+            background: 'transparent', color: '#e0fbfc', border: '1px solid rgba(255,255,255,0.3)',
+            padding: '6px 10px', borderRadius: 8, cursor: 'pointer'
+          }}>Close</button>
+        </div>
+
+        <div style={{ padding: 16, display: 'grid', gap: 16 }}>
+          <p style={{ opacity: 0.9, margin: 0 }}>Compact chart for common decisions. Dealer stands on 17. Pair splits and surrender not included.</p>
+
+          <Section title='Hard Totals'>
+            <Rule total='17+' action='Stand' detail='Always' />
+            <Rule total='16' action='Stand' detail='vs 2–6; else Hit' />
+            <Rule total='15' action='Stand' detail='vs 2–6; else Hit' />
+            <Rule total='13–14' action='Stand' detail='vs 2–6; else Hit' />
+            <Rule total='12' action='Stand' detail='vs 4–6; else Hit' />
+            <Rule total='11' action='Double' detail='vs 2–10; vs A Hit' />
+            <Rule total='10' action='Double' detail='vs 2–9; else Hit' />
+            <Rule total='9' action='Double' detail='vs 3–6; else Hit' />
+            <Rule total='8 or less' action='Hit' detail='Always' />
+          </Section>
+
+          <Section title='Soft Totals (A counted as 11)'>
+            <Rule total='A,8+ (19–21)' action='Stand' detail='Always' />
+            <Rule total='A,7 (18)' action='Double' detail='vs 3–6; vs 2/7/8 Stand; else Hit' />
+            <Rule total='A,6 (17)' action='Double' detail='vs 3–6; else Hit' />
+            <Rule total='A,4–A,5 (15–16)' action='Double' detail='vs 4–6; else Hit' />
+            <Rule total='A,2–A,3 (13–14)' action='Double' detail='vs 5–6; else Hit' />
+          </Section>
+
+          <div style={{ fontSize: 12, opacity: 0.8 }}>
+            Note: If Double is unavailable, take the fallback (Hit or Stand) indicated by hints on the table.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }) {
+  return (
+    <div>
+      <div style={{ fontWeight: 700, marginBottom: 8 }}>{title}</div>
+      <div style={{ display: 'grid', gap: 6 }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Rule({ total, action, detail }) {
+  return (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '160px 120px 1fr',
+      gap: 8, alignItems: 'center', padding: '6px 8px',
+      background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 8
+    }}>
+      <div style={{ opacity: 0.9 }}>{total}</div>
+      <div style={{ fontWeight: 700, color: '#9fffc7' }}>{action}</div>
+      <div style={{ opacity: 0.9 }}>{detail}</div>
+    </div>
+  )
+}

--- a/app/src/game/deck.js
+++ b/app/src/game/deck.js
@@ -1,0 +1,31 @@
+const SUITS = ['♠', '♥', '♦', '♣']
+const RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K']
+
+export function createDeck() {
+  const deck = []
+  for (const s of SUITS) {
+    for (const r of RANKS) {
+      deck.push({ rank: r, suit: s })
+    }
+  }
+  return deck
+}
+
+export function shuffle(deck, rng = Math.random) {
+  // Fisher-Yates
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[deck[i], deck[j]] = [deck[j], deck[i]]
+  }
+  return deck
+}
+
+export function draw(deck, n = 1) {
+  const cards = []
+  for (let i = 0; i < n; i++) cards.push(deck.pop())
+  return cards
+}
+
+export function formatCard(card) {
+  return card ? `${card.rank}${card.suit}` : ''
+}

--- a/app/src/main.jsx
+++ b/app/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import './styles.css'
 
 const root = createRoot(document.getElementById('root'))
 root.render(
@@ -8,4 +9,3 @@ root.render(
     <App />
   </React.StrictMode>
 )
-

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1,0 +1,154 @@
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px) scale(0.98) }
+  to { opacity: 1; transform: translateY(0) scale(1) }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0 }
+  to { opacity: 1 }
+}
+
+@keyframes pop {
+  from { opacity: 0; transform: translateY(8px) scale(0.96) }
+  to { opacity: 1; transform: translateY(0) scale(1) }
+}
+
+.card:hover {
+  transform: translateY(-2px) rotate(-0.25deg);
+  box-shadow: 0 6px 14px rgba(0,0,0,0.25);
+}
+
+.btn {
+  box-shadow: 0 2px 0 rgba(0,0,0,0.15);
+}
+.btn:hover {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.25);
+}
+.btn:active {
+  transform: translateY(0) scale(0.98);
+  box-shadow: 0 1px 0 rgba(0,0,0,0.15);
+}
+
+/* Playing card visuals */
+.playing-card {
+  position: relative;
+  background: linear-gradient(180deg, #ffffff, #f8f9fb);
+  border: 1px solid rgba(0,0,0,0.18);
+  border-radius: 10px;
+  box-shadow: 0 6px 16px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,255,255,0.7);
+  color: #111;
+  user-select: none;
+}
+.playing-card.red { color: #c62828 }
+.playing-card.black { color: #111 }
+.playing-card .corner {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  line-height: 1;
+}
+.playing-card .corner.top-left { top: 6px; left: 6px }
+.playing-card .corner.bottom-right { bottom: 6px; right: 6px; transform: rotate(180deg) }
+.playing-card .corner .rank { font-weight: 800; font-size: 16px }
+.playing-card .corner .suit { font-size: 14px }
+.playing-card .pips { position: relative; width: 100%; height: 100% }
+.playing-card .pip {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-size: 18px;
+  line-height: 1;
+}
+.playing-card .pip.ace {
+  top: 50%; left: 50%; transform: translate(-50%, -50%);
+  font-size: 42px;
+}
+.playing-card .watermark {
+  position: absolute;
+  top: 50%; left: 50%; transform: translate(-50%, -50%);
+  font-size: 50px; line-height: 1;
+  opacity: 0.12;
+}
+.playing-card .face-art {
+  position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+  font-weight: 900; font-size: 38px; letter-spacing: 1px;
+  color: currentColor;
+  text-shadow: 0 1px 0 rgba(255,255,255,0.6), 0 2px 8px rgba(0,0,0,0.35);
+}
+
+.card-back {
+  position: relative;
+  background:
+    repeating-linear-gradient(45deg, #1c2541 0, #1c2541 6px, #3a506b 6px, #3a506b 12px);
+  border: 1px solid rgba(0,0,0,0.25);
+  border-radius: 10px;
+  box-shadow: 0 6px 16px rgba(0,0,0,0.28), inset 0 0 0 2px rgba(255,255,255,0.08);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 9999px;
+  font-size: 12px;
+  border: 1px solid rgba(255,255,255,0.2);
+  background: rgba(255,255,255,0.06);
+  color: #e0fbfc;
+  user-select: none;
+}
+.chip--win {
+  background: rgba(159,255,199,0.15);
+  border-color: rgba(159,255,199,0.5);
+  color: #9fffc7;
+}
+.chip--lose {
+  background: rgba(255,94,91,0.15);
+  border-color: rgba(255,94,91,0.5);
+  color: #ffb3b1;
+}
+.chip--push {
+  background: rgba(224,251,252,0.08);
+  border-color: rgba(224,251,252,0.35);
+  color: #e0fbfc;
+}
+.chip--bj {
+  background: rgba(255,209,102,0.16);
+  border-color: rgba(255,209,102,0.55);
+  color: #ffe29a;
+}
+
+/* Table felt and seats */
+.table-felt {
+  position: relative;
+}
+.seats .seat {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #cfd8dc, #90a4ae);
+  border: 2px solid rgba(0,0,0,0.35);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+}
+/* place 8 seats roughly around the oval */
+.seats .seat-1 { top: 8px; left: 50%; transform: translate(-50%, 0); }
+.seats .seat-2 { top: 18%; right: 10%; }
+.seats .seat-3 { top: 50%; right: 4%; transform: translate(0, -50%); }
+.seats .seat-4 { bottom: 18%; right: 10%; }
+.seats .seat-5 { bottom: 8px; left: 50%; transform: translate(-50%, 0); }
+.seats .seat-6 { bottom: 18%; left: 10%; }
+.seats .seat-7 { top: 50%; left: 4%; transform: translate(0, -50%); }
+.seats .seat-8 { top: 18%; left: 10%; }
+
+/* Strategy dock */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 11px;
+  border: 1px solid transparent;
+}
+.act-stand { background: rgba(100,181,246,0.18); border-color: rgba(100,181,246,0.5); color: #a7d5ff; }
+.act-hit { background: rgba(46,204,113,0.18); border-color: rgba(46,204,113,0.5); color: #b8f7cd; }
+.act-double { background: rgba(241,196,15,0.2); border-color: rgba(241,196,15,0.55); color: #ffe29a; }


### PR DESCRIPTION
…tic cards\n\n- Move strategy to bottom-right dock with expand/collapse\n- Add data-driven, color-coded strategy table with highlighting\n- Remove center strategy hint and old in-table panel\n- Keep dealer top / player bottom layout and center controls\n- Outcomes table (top-right): last 10 outcomes, stacking, no time column\n- Card visuals: realistic faces/backs, correct pip layouts 2–10, distinct faces\n- Animations and spacing polish

- Summary: Overhauls the blackjack table UI.
  - Strategy moved to a bottom-right dock with expand/collapse, color-coded rule
s, centered Vs column, and live highlighting for current hand vs dealer upcard. 
Removed center strategy hint and the old in-table panel.
  - Outcomes table (top-right) shows the last 10 outcomes, with newest on top an
d automatic trimming. Simplified columns (index, outcome, type).
  - Layout refactor keeps dealer at the top and player at the bottom with centra
l controls.
  - Playing cards redesigned: realistic faces/backs; 2–10 show correct pip layou
ts; Ace with single pip; J/Q/K distinct face art; red/black suits, corner indice
s, subtle center watermark.
  - Retains smooth staggered animations and felt table with seats.
- Screenshots: [add GIF or images]
- Test plan:
  - npm --prefix app ci && npm --prefix app run build
  - wrangler pages dev app/dist --port 8790
  - Deal multiple rounds; verify:
    - Strategy dock expands, highlights applicable row based on the dealt player
 hand and dealer upcard; “else Hit/Stand” tags are color-coded.
    - Outcomes table stacks newest first and caps at 10.
    - Dealer cards render top; player bottom; controls centered.
    - Cards display correct pips, faces, and backs; animations look smooth.
- Notes:
  - No env/secrets changes.
  - No API changes.