### PR TITLE
Add LLM dealer chat with voice interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Deployment (Cloudflare Pages)
 
 API Example
 - GET /api/hello → JSON health response.
+- POST /api/dealer → proxy to an LLM; send `{ messages: [...] }` and receive `{ reply }`. Requires `OPENAI_API_KEY` secret.
+- Add the key with `wrangler secret put OPENAI_API_KEY`.
 
 PWA Notes
 - Manifest: `app/public/manifest.webmanifest`
@@ -56,3 +58,4 @@ Features
 - Game engine: shuffling/dealing, hit/stand, outcome resolution.
 - Basic strategy hints: UI highlights recommended action based on player/dealer up-card.
 - Strategy help modal: compact chart (S17, no splits/surrender). Open via Strategy button or press `?`.
+- Voice dealer: use the Chat button to speak with the dealer. Dealer replies are powered by an LLM and spoken via Web Speech.

--- a/app/src/components/DealerChat.jsx
+++ b/app/src/components/DealerChat.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
+
+export default function DealerChat({ onSpeak }) {
+  const [messages, setMessages] = useState([])
+  const [listening, setListening] = useState(false)
+  const recRef = useRef(null)
+
+  useEffect(() => {
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition
+    if (!SR) return
+    const r = new SR()
+    r.lang = 'en-US'
+    r.interimResults = false
+    r.onresult = e => {
+      const text = e.results[0][0].transcript
+      handleUserText(text)
+    }
+    r.onend = () => setListening(false)
+    recRef.current = r
+  }, [])
+
+  async function handleUserText(text) {
+    const next = [...messages, { role: 'user', text }]
+    setMessages(next)
+    const payload = {
+      messages: [
+        { role: 'system', content: 'You are a friendly casino dealer. Keep replies brief.' },
+        ...next.map(m => ({ role: m.role === 'user' ? 'user' : 'assistant', content: m.text }))
+      ]
+    }
+    try {
+      const res = await fetch('/api/dealer', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      const data = await res.json()
+      const reply = data.reply || ''
+      setMessages(m => [...m, { role: 'dealer', text: reply }])
+      onSpeak?.(reply)
+    } catch {}
+  }
+
+  function start() {
+    const r = recRef.current
+    if (!r || listening) return
+    setListening(true)
+    r.start()
+  }
+
+  return (
+    <div style={{ marginTop: 10, textAlign: 'center' }}>
+      <button className='btn' onClick={start} disabled={listening} style={{ padding: '8px 12px', borderRadius: 8 }}>
+        {listening ? 'Listening…' : 'Chat'}
+      </button>
+      <div style={{ marginTop: 6, fontSize: 12, maxWidth: 260, marginLeft: 'auto', marginRight: 'auto' }}>
+        {messages.slice(-2).map((m, i) => (
+          <div key={i} style={{ opacity: 0.85 }}>
+            <strong>{m.role === 'user' ? 'You' : 'Dealer'}:</strong> {m.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/DealerVoice.jsx
+++ b/app/src/components/DealerVoice.jsx
@@ -73,6 +73,10 @@ export default function DealerVoice({ enabled, event }) {
         speak(wrap)
         break
       }
+      case 'chat': {
+        speak(e.text)
+        break
+      }
       default:
         break
     }

--- a/app/src/components/GameTable.jsx
+++ b/app/src/components/GameTable.jsx
@@ -6,6 +6,7 @@ import { basicStrategy, formatSuggestion } from '../game/strategy.js'
 import StrategyHelp from './StrategyHelp.jsx'
 import { useEffect } from 'react'
 import DealerVoice from './DealerVoice.jsx'
+import DealerChat from './DealerChat.jsx'
 import useAmbientMusic from '../hooks/useAmbientMusic.js'
 
 function Card({ c, hidden = false, delayMs = 0 }) {
@@ -371,6 +372,7 @@ export default function GameTable({ onStrategyContext }) {
           <Toggle on={voiceOn} onClick={() => setVoiceOn(v => !v)}>Voice</Toggle>
           <Toggle on={musicOn} onClick={() => { const next = !musicOn; setMusicOn(next); if (next) music.start(); else music.stop() }}>Music</Toggle>
         </div>
+        <DealerChat onSpeak={text => setVoiceEvent({ id: Date.now() + '-chat', type: 'chat', text })} />
       </div>
 
       <StrategyHelp open={showHelp} onClose={() => setShowHelp(false)} />

--- a/functions/api/dealer.js
+++ b/functions/api/dealer.js
@@ -1,0 +1,35 @@
+export async function onRequest({ request, env }) {
+  try {
+    const { messages = [] } = await request.json()
+    const apiKey = env.OPENAI_API_KEY
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: 'missing api key' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+    const payload = {
+      model: 'gpt-3.5-turbo',
+      messages,
+      max_tokens: 100
+    }
+    const r = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(payload)
+    })
+    const data = await r.json()
+    const reply = data.choices?.[0]?.message?.content?.trim() || ''
+    return new Response(JSON.stringify({ reply }), {
+      headers: { 'content-type': 'application/json' }
+    })
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Add `/api/dealer` function to proxy chat messages to OpenAI
- Introduce `DealerChat` component with speech recognition and LLM replies
- Extend dealer voice to speak chat responses and wire into game table
- Document dealer chat and required `OPENAI_API_KEY`

## Testing
- `npm install`
- `npm run build`
- `timeout 5 npx --yes wrangler pages dev app/dist` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6896c28b9b888322ae0b5b30a754e345